### PR TITLE
Fix synatx error for older git versions

### DIFF
--- a/.ps1rc
+++ b/.ps1rc
@@ -2,7 +2,7 @@
 source ~/.git-prompt.sh
 
 # PS1 Colorful
-PS1='\[\e[0;35m\]\u \[\e[0;37m\]@ \[\e[0;32m\]\h \[\e[0;33m\]\w\[\e[0;36m\]$(__git_ps1 " (%s)")\[\e[0m\]\n\$ '
+PS1='\[\e[0;35m\]\u \[\e[0;37m\]@ \[\e[0;32m\]\h \[\e[0;33m\]\w\[\e[0;36m\]`__git_ps1 " (%s)"`\[\e[0m\]\n\$ '
 # PS1 Colorless
 # PS1='[\u@\h \W$(__git_ps1 " (%s)")]\$ '
 


### PR DESCRIPTION

```
bash: command substitution: line 1: syntax error near unexpected token `)
bash: command substitution: line 1: `__git_ps1 " (%s)")
```

The error occurs specifically on this line:
`PS1='\[\e[0;35m\]\u \[\e[0;37m\]@ \[\e[0;32m\]\h \[\e[0;33m\]\w\[\e[0;36m\]$(__git_ps1 " (%s)")\[\e[0m\]\n\$ '
`

The $(__git_ps1 " (%s)") portion is causing the issue.

If you're using an older version of Bash that doesn't support the syntax used for command substitution, you can try an alternative approach. Here's how you can modify your PS1 prompt to avoid this issue:

`PS1='\[\e[0;35m\]\u \[\e[0;37m\]@ \[\e[0;32m\]\h \[\e[0;33m\]\w\[\e[0;36m\]`__git_ps1 " (%s)"`\[\e[0m\]\n\$ '`

This alternative approach involves using backticks () for command substitution instead of the $()` syntax. Here's the modified line:

